### PR TITLE
feat: Add optional debug flag to LLM providers

### DIFF
--- a/src/providers/WebLlmProvider.ts
+++ b/src/providers/WebLlmProvider.ts
@@ -15,6 +15,7 @@ class WebLlmProvider implements Provider {
 	private chatCompletionOptions: Record<string, unknown>;
 	private messageParser?: (messages: Message[]) => WebLlmProviderMessage[];
 	private engine?: MLCEngine;
+	private debug: boolean = false;
 
 	/**
 	 * Sets default values for the provider based on given configuration. Configuration guide here:
@@ -29,6 +30,7 @@ class WebLlmProvider implements Provider {
 		this.messageParser = config.messageParser;
 		this.engineConfig = config.engineConfig ?? {};
 		this.chatCompletionOptions = config.chatCompletionOptions ?? {};
+		this.debug = config.debug ?? false;
 		this.createEngine();
 	}
 
@@ -50,6 +52,17 @@ class WebLlmProvider implements Provider {
 	public async *sendMessages(messages: Message[]): AsyncGenerator<string> {
 		if (!this.engine) {
 			await this.createEngine();
+		}
+
+		if (this.debug) {
+			console.log('[WebLlmProvider] Request:', {
+				model: this.model,
+				systemMessage: this.systemMessage,
+				responseFormat: this.responseFormat,
+				engineConfig: this.engineConfig,
+				chatCompletionOptions: this.chatCompletionOptions,
+				messages: this.constructBodyWithMessages(messages).messages, // Log messages being sent
+			});
 		}
 
 		const result = await this.engine?.chat.completions.create(this.constructBodyWithMessages(messages));

--- a/src/types/provider-config/GeminiProviderConfig.ts
+++ b/src/types/provider-config/GeminiProviderConfig.ts
@@ -15,6 +15,7 @@ type DirectConfig = {
 	headers?: Record<string, string>;
 	body?: Record<string, string>;
 	messageParser?: (messages: Message[]) => GeminiProviderMessage[];
+	debug?: boolean;
 };
 
 /**
@@ -30,6 +31,7 @@ type ProxyConfig = {
 	headers?: Record<string, string>;
 	body?: Record<string, string>;
 	messageParser?: (messages: Message[]) => GeminiProviderMessage[];
+	debug?: boolean;
 };
 
 /**

--- a/src/types/provider-config/OpenaiProviderConfig.ts
+++ b/src/types/provider-config/OpenaiProviderConfig.ts
@@ -15,6 +15,7 @@ type DirectConfig = {
 	headers?: Record<string, string>;
 	body?: Record<string, string>;
 	messageParser?: (messages: Message[]) => OpenaiProviderMessage[];
+	debug?: boolean;
 };
 
 /**
@@ -30,6 +31,7 @@ type ProxyConfig = {
 	headers?: Record<string, string>;
 	body?: Record<string, string>;
 	messageParser?: (messages: Message[]) => OpenaiProviderMessage[];
+	debug?: boolean;
 };
 
 /**

--- a/src/types/provider-config/WebLlmProviderConfig.ts
+++ b/src/types/provider-config/WebLlmProviderConfig.ts
@@ -12,6 +12,7 @@ type WebLlmProviderConfig = {
 	engineConfig?: MLCEngineConfig;
 	chatCompletionOptions?: Record<string, unknown>;
 	messageParser?: (messages: Message[]) => WebLlmProviderMessage[];
+	debug?: boolean;
 };
 
 export type { WebLlmProviderConfig };


### PR DESCRIPTION
This commit introduces an optional `debug` boolean configuration to the OpenAI, Gemini, and WebLlm providers.

When `debug` is set to `true` in the provider's configuration, the provider will print useful debugging information to the console. This includes:

- For OpenAI and Gemini providers:
    - The HTTP method being used.
    - The endpoint URL (API keys in Gemini's direct mode URL are redacted).
    - Request headers (with 'Authorization' header redacted for OpenAI).
    - The request body.
- For WebLlmProvider:
    - The model being used.
    - The system message.
    - The response format.
    - The engine configuration.
    - Chat completion options.
    - The messages being processed.

This feature is intended to help you troubleshoot issues with LLM provider integrations, especially when using proxy mode or when unexpected responses are received. The `debug` option defaults to `false` if not specified.

#### Description

Please include a brief summary of the change and include the relevant issue(s).

Closes #(issue)

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Please give a short overview/explanation on the approach taken to resolve the issue(s).

#### Checklist:

- [ ] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)